### PR TITLE
Replace manual lookup with static hashmap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cloudsay"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Spaceface16518 <33424649+Spaceface16518@users.noreply.github.com>"]
 edition = "2018"
 
@@ -10,3 +10,5 @@ pretty_env_logger = "0.3"
 smallvec = "0.6"
 actix-web = "0.7"
 serde = { version = "1.0", features = ["derive"] }
+hashbrown = "0.1"
+lazy_static = "1.2"

--- a/src/lib/say/character.rs
+++ b/src/lib/say/character.rs
@@ -1,26 +1,40 @@
 use super::statics;
+use hashbrown::HashMap;
+use lazy_static::lazy_static;
 use log::{error, trace};
 
 pub type Character = &'static [u8];
 
-#[inline]
-pub const fn cow() -> Character { statics::COW }
-
-#[inline]
-pub const fn ferris() -> Character { statics::FERRIS }
+lazy_static! {
+    static ref CHAR_TABLE: HashMap<&'static str, &'static [u8]> = {
+        let mut tmp = HashMap::with_capacity(2);
+        tmp.insert("cow", statics::COW);
+        tmp.insert("ferris", statics::FERRIS);
+        tmp
+    };
+}
 
 #[inline]
 pub fn get_character(name: &str) -> Result<Character, CharacterLookupError> {
     trace!("Looking up character");
-    match name {
-        "cow" => Ok(cow()),
-        "ferris" => Ok(ferris()),
-        _ => {
-            error!("Character lookup failed");
-            Err(CharacterLookupError {
-                attempt: name.to_string(),
-            })
-        },
+    // match name {
+    //     "cow" => Ok(cow()),
+    //     "ferris" => Ok(ferris()),
+    //     _ => {
+    //         error!("Character lookup failed");
+    //         Err(CharacterLookupError {
+    //             attempt: name.to_string(),
+    //         })
+    //     },
+    // }
+
+    if let Some(&c) = CHAR_TABLE.get(name) {
+        Ok(c)
+    } else {
+        error!("Character lookup failed");
+        Err(CharacterLookupError {
+            attempt: name.to_string(),
+        })
     }
 }
 
@@ -47,11 +61,11 @@ mod character_tests {
 
     #[test]
     fn test_get_character_input_cow() {
-        assert_eq!(get_character("cow").unwrap(), cow());
+        assert_eq!(get_character("cow").unwrap(), statics::COW);
     }
 
     #[test]
     fn test_get_character_input_ferris() {
-        assert_eq!(get_character("ferris").unwrap(), ferris());
+        assert_eq!(get_character("ferris").unwrap(), statics::FERRIS);
     }
 }


### PR DESCRIPTION
If this causes it to slow down, it will be removed. Must implement unit testing (and benchmarking) to find that out though